### PR TITLE
ci: skip foundry.lock + .gitignore from soldeer publishes

### DIFF
--- a/.soldeerignore
+++ b/.soldeerignore
@@ -1,7 +1,23 @@
-# Soldeer flags .gitignore and foundry.lock as "sensitive" and prompts
-# for interactive confirmation on push. CI doesn't have a TTY, so the
-# prompt fails with "not connected" and the publish dies. Neither file
-# is actually sensitive (no secrets), but consumers of the package have
-# no use for them either — just skip them.
+.DS_Store
+.coderabbitai.yaml
+.gas-snapshot
+.git
+.github
 .gitignore
-foundry.lock
+.gitmodules
+.pre-commit-config.yaml
+.soldeerignore
+.vscode
+CLAUDE.md
+/audit
+/cache
+/dependencies
+/flake.lock
+/flake.nix
+/foundry.lock
+/foundry.toml
+/out
+/remappings.txt
+/slither.config.json
+/soldeer.lock
+/REUSE.toml

--- a/.soldeerignore
+++ b/.soldeerignore
@@ -1,0 +1,7 @@
+# Soldeer flags .gitignore and foundry.lock as "sensitive" and prompts
+# for interactive confirmation on push. CI doesn't have a TTY, so the
+# prompt fails with "not connected" and the publish dies. Neither file
+# is actually sensitive (no secrets), but consumers of the package have
+# no use for them either — just skip them.
+.gitignore
+foundry.lock

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -17,6 +17,7 @@ path = [
   "foundry.lock",
   "remappings.txt",
   "soldeer.lock",
+  ".soldeerignore",
 ]
 SPDX-FileCopyrightText = "Copyright (c) 2020 thedavidmeister"
 SPDX-License-Identifier = "LicenseRef-DCL-1.0"


### PR DESCRIPTION
Adds `.soldeerignore` excluding `foundry.lock` and `.gitignore` from `forge soldeer push`.

Soldeer flags both filenames as sensitive and prompts interactively before continuing the push. CI doesn't have a TTY on stdin, so the prompt fails with `error during IO operation for '': not connected` and the whole publish aborts. The v0.1.0 publish has hit this twice already (runs 26237044461 and 26237910066).

Neither file actually contains secrets — they're just on soldeer's hardcoded sensitive-name list. Consumers of the package have no use for them either, so the simplest fix is to exclude them from the publish payload.

After merge, retagging v0.1.0 will retrigger the publish and should succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to improve CI/CD pipeline reliability and prevent prompt failures in automated environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/raindex.interface/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->