### PR TITLE
docs: removeOrder3 emits RemoveOrderV3 only on state change

### DIFF
--- a/src/interface/IRaindexV6.sol
+++ b/src/interface/IRaindexV6.sol
@@ -452,9 +452,13 @@ interface IRaindexV6 is IERC3156FlashLender, IInterpreterCallerV4 {
 
     /// Order owner can remove their own orders. Delegated order removal is NOT
     /// supported and will revert. Removing an order multiple times or removing
-    /// an order that never existed are valid, the event will be emitted and the
-    /// transaction will complete with that order hash definitely, redundantly
-    /// not live.
+    /// an order that never existed are valid; the transaction will complete
+    /// with that order hash definitely, redundantly not live.
+    ///
+    /// If a live order is removed the Raindex MUST change state, emit a
+    /// `RemoveOrderV3` event and return true. If the order is not live the
+    /// Raindex MUST NOT change state, which includes not emitting an event.
+    /// Instead it MUST return false.
     ///
     /// @param order The `Order` data exactly as it was added.
     /// @param tasks Additional tasks to run after the order is removed.


### PR DESCRIPTION
## What

Doc-only fix to the `removeOrder3` NatSpec in `IRaindexV6.sol`. This is
the authoritative source consumed via `@inheritdoc` by the raindex
implementation.

## Why

The prose said removing an order multiple times or removing one that
never existed is valid and "the event will be emitted". That
unconditional claim contradicts the `@return stateChanged` doc on the
same function ("false if it did not exist") and the actual code, which
guards the `RemoveOrderV3` emit (and post tasks) behind a live-order
check: a dead / never-existing removal is a no-op that returns false and
emits nothing.

Per the maintainer decision on rainlanguage/raindex#2669 ("emit events
when there is a state change; update the docs to match the code"), this
reconciles the prose with the no-op semantics:

- A live order removal MUST change state, emit `RemoveOrderV3`, and
  return true.
- A not-live (already-dead / never-existing) removal MUST NOT change
  state or emit an event, and returns false.

This mirrors the symmetric `addOrder4` spec a few lines above. The
`@return stateChanged` doc is unchanged and now consistent with the
prose. Deprecated v1-v4 interfaces are intentionally left untouched.

## Testing

Doc-only change. `forge build` succeeds and `forge fmt --check` is
clean. A NatSpec comment has no observable runtime behavior and this
interface-only package has no test harness or doc-gen in CI, so there is
no compiled artifact a test could assert against; no behavioral test is
applicable.

Resolves rainlanguage/raindex#2669

🤖 Generated with [Claude Code](https://claude.com/claude-code)
