### PR TITLE
Migrate rain-interpreter-interface 0.1.0 -> rainlang-interface 0.2.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,17 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working with
+code in this repository.
 
 ## Project Overview
 
-Solidity interface library for Raindex (Rain Protocol's onchain order book). Defines interfaces and types for an order book where orders are strategies expressed as Rainlang interpreter bytecode. Part of the Rain Protocol ecosystem.
+Solidity interface library for Raindex (Rain Protocol's onchain order book).
+Defines interfaces and types for an order book where orders are strategies
+expressed as Rainlang interpreter bytecode. Part of the Rain Protocol ecosystem.
 
-License: DecentraLicense 1.0 (DCL-1.0). REUSE 3.2 compliant — all files need SPDX headers:
+License: DecentraLicense 1.0 (DCL-1.0). REUSE 3.2 compliant — all files need
+SPDX headers:
+
 ```solidity
 // SPDX-License-Identifier: LicenseRef-DCL-1.0
 // SPDX-FileCopyrightText: Copyright (c) 2020 thedavidmeister
@@ -14,7 +19,8 @@ License: DecentraLicense 1.0 (DCL-1.0). REUSE 3.2 compliant — all files need S
 
 ## Build & Development
 
-Requires the Nix package manager. **Only use the nix version of Foundry**, not a system-installed one.
+Requires the Nix package manager. **Only use the nix version of Foundry**, not a
+system-installed one.
 
 ```bash
 nix develop                    # Enter dev shell
@@ -24,45 +30,71 @@ rainix-sol-static              # Static analysis (Slither)
 rainix-sol-legal               # License/REUSE compliance check
 ```
 
-Compiler: Solidity 0.8.25, EVM target: cancun, optimizer enabled (1M runs). Fuzz tests run 2048 iterations.
+Compiler: Solidity 0.8.25, EVM target: cancun, optimizer enabled (1M runs). Fuzz
+tests run 2048 iterations.
 
 ## Architecture
 
 ### Interfaces (`src/interface/`)
 
-- **IRaindexV6** — Current stable interface. Vault-based order book with deposit/withdraw, add/remove orders, take orders (market buy), and clear (match two orders with bounty). IERC3156 flash loan compliant. Supports vaultless orders (vault ID `0` means tokens move directly from wallet) and input/output-based take order limits via `IOIsInput` flag.
-- **IRaindexV6OrderTaker / IRaindexV6ArbOrderTaker** — Callback interfaces for takers receiving tokens during `takeOrders`.
-- **ierc3156/** — Flash loan interfaces (IERC3156FlashLender, IERC3156FlashBorrower).
-- **deprecated/** (v1-v5) — Old interface versions. Do not modify unless undeprecating.
+- **IRaindexV6** — Current stable interface. Vault-based order book with
+  deposit/withdraw, add/remove orders, take orders (market buy), and clear
+  (match two orders with bounty). IERC3156 flash loan compliant. Supports
+  vaultless orders (vault ID `0` means tokens move directly from wallet) and
+  input/output-based take order limits via `IOIsInput` flag.
+- **IRaindexV6OrderTaker / IRaindexV6ArbOrderTaker** — Callback interfaces for
+  takers receiving tokens during `takeOrders`.
+- **ierc3156/** — Flash loan interfaces (IERC3156FlashLender,
+  IERC3156FlashBorrower).
+- **deprecated/** (v1-v5) — Old interface versions. Do not modify unless
+  undeprecating.
 
 ### Interface Lifecycle
 
-Stable interfaces live directly in `src/interface/`. New unstable interfaces go in `src/interface/unstable/` until stabilised. When stabilising, move from `unstable/` to `src/interface/` and move the previous stable version to `deprecated/v<N>/`.
+Stable interfaces live directly in `src/interface/`. New unstable interfaces go
+in `src/interface/unstable/` until stabilised. When stabilising, move from
+`unstable/` to `src/interface/` and move the previous stable version to
+`deprecated/v<N>/`.
 
 ### Key Types
 
-All amounts and ratios are Rain floating point (`Float` from `rain.math.float`). Converted to absolute token values via `decimals()` only when tokens actually move.
+All amounts and ratios are Rain floating point (`Float` from `rain.math.float`).
+Converted to absolute token values via `decimals()` only when tokens actually
+move.
 
-- `OrderV4` — Deployed order: owner, evaluable (interpreter + store + bytecode), valid inputs/outputs, nonce
+- `OrderV4` — Deployed order: owner, evaluable (interpreter + store + bytecode),
+  valid inputs/outputs, nonce
 - `OrderConfigV4` — Config for adding an order, includes meta and secret
 - `IOV2` — Input/output config: token address + vault ID
 - `TaskV2` — Evaluable + signed context, for post-operation callbacks
 - `TakeOrdersConfigV4` / `TakeOrdersConfigV5` — Config for batch taking orders
-- `ClearConfigV2` / `ClearStateChangeV2` — Config and result for clearing two matched orders
+- `ClearConfigV2` / `ClearStateChangeV2` — Config and result for clearing two
+  matched orders
 
 ### Dependencies
 
-Soldeer packages, declared in `[dependencies]` in `foundry.toml` and locked in `soldeer.lock` (run `forge soldeer update` after changing them). Import paths carry the package version (e.g. `rainlang-interface-0.2.3/src/...`). Direct deps: `rainlang-interface` (Rainlang interpreter interfaces and caller libs) and `rain-math-float` (Float). Soldeer resolution is flat, so `[dependencies]` also declares everything `rainlang-interface`'s own src imports (`@openzeppelin-contracts`, `rain-lib-hash`, `rain-math-binary`, `rain-sol-codegen`, `rain-solmem`).
+Soldeer packages, declared in `[dependencies]` in `foundry.toml` and locked in
+`soldeer.lock` (run `forge soldeer update` after changing them). Import paths
+carry the package version (e.g. `rainlang-interface-0.2.3/src/...`). Direct
+deps: `rainlang-interface` (Rainlang interpreter interfaces and caller libs) and
+`rain-math-float` (Float). Soldeer resolution is flat, so `[dependencies]` also
+declares everything `rainlang-interface`'s own src imports
+(`@openzeppelin-contracts`, `rain-lib-hash`, `rain-math-binary`,
+`rain-sol-codegen`, `rain-solmem`).
 
 ## Conventions
 
-- All reverts use custom errors — no `revert("string")` or `require()` with string messages.
-- Interfaces use `pragma solidity ^0.8.18` (note: differs from interpreter interface which uses `^0.8.25`).
-- Versioned naming: interfaces (`IRaindexV6`), structs (`OrderV4`, `ClearConfigV2`), events (`AddOrderV3`), functions (`deposit4`, `withdraw4`).
-- Use `//forge-lint: disable-next-line(...)` comments for lint suppressions: `unused-import`, `mixed-case-variable`, `pascal-case-struct`.
-- Use `//forge-lint: disable-start(...)`/`disable-end(...)` for multi-line suppressions.
+- All reverts use custom errors — no `revert("string")` or `require()` with
+  string messages.
+- Interfaces use `pragma solidity ^0.8.18` (note: differs from interpreter
+  interface which uses `^0.8.25`).
+- Versioned naming: interfaces (`IRaindexV6`), structs (`OrderV4`,
+  `ClearConfigV2`), events (`AddOrderV3`), functions (`deposit4`, `withdraw4`).
+- Use `//forge-lint: disable-next-line(...)` comments for lint suppressions:
+  `unused-import`, `mixed-case-variable`, `pascal-case-struct`.
 - Branch naming: `YYYY-MM-DD-description`.
 
 ## Slither Config
 
-Excluded detectors: `assembly-usage`, `solc-version`, `unused-imports`, `pragma`. Filtered paths: `forge-std`, `openzeppelin`, `rain.math.float`.
+Excluded detectors: `assembly-usage`, `solc-version`, `unused-imports`,
+`pragma`. Filtered paths: `forge-std`, `openzeppelin`, `rain.math.float`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,10 +52,7 @@ All amounts and ratios are Rain floating point (`Float` from `rain.math.float`).
 
 ### Dependencies
 
-Single git submodule: `lib/rain.interpreter.interface` (interpreter interfaces, math libraries, utilities). Remapping in `foundry.toml`:
-```
-rain.math.float/=lib/rain.interpreter.interface/lib/rain.math.float/src/
-```
+Soldeer packages, declared in `[dependencies]` in `foundry.toml` and locked in `soldeer.lock` (run `forge soldeer update` after changing them). Import paths carry the package version (e.g. `rainlang-interface-0.2.3/src/...`). Direct deps: `rainlang-interface` (Rainlang interpreter interfaces and caller libs) and `rain-math-float` (Float). Soldeer resolution is flat, so `[dependencies]` also declares everything `rainlang-interface`'s own src imports (`@openzeppelin-contracts`, `rain-lib-hash`, `rain-math-binary`, `rain-sol-codegen`, `rain-solmem`).
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,5 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with
-code in this repository.
-
 ## Project Overview
 
 Solidity interface library for Raindex (Rain Protocol's onchain order book).

--- a/foundry.lock
+++ b/foundry.lock
@@ -1,5 +1,0 @@
-{
-  "lib/rain.interpreter.interface": {
-    "rev": "58386557c270301d4eeaa0b101f2326b0cf4db68"
-  }
-}

--- a/foundry.toml
+++ b/foundry.toml
@@ -29,8 +29,13 @@ evm_version = "cancun"
 
 [dependencies]
 forge-std = "1.16.1"
-rain-interpreter-interface = "0.1.0"
+rainlang-interface = "0.2.3"
 rain-math-float = "0.1.1"
+"@openzeppelin-contracts" = "5.6.1"
+rain-lib-hash = "0.1.0"
+rain-math-binary = "0.1.4"
+rain-sol-codegen = "0.1.0"
+rain-solmem = "0.1.3"
 
 [soldeer]
 recursive_deps = false

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,3 +1,8 @@
+@openzeppelin-contracts-5.6.1/=dependencies/@openzeppelin-contracts-5.6.1/
 forge-std-1.16.1/=dependencies/forge-std-1.16.1/
-rain-interpreter-interface-0.1.0/=dependencies/rain-interpreter-interface-0.1.0/
+rain-lib-hash-0.1.0/=dependencies/rain-lib-hash-0.1.0/
+rain-math-binary-0.1.4/=dependencies/rain-math-binary-0.1.4/
 rain-math-float-0.1.1/=dependencies/rain-math-float-0.1.1/
+rain-sol-codegen-0.1.0/=dependencies/rain-sol-codegen-0.1.0/
+rain-solmem-0.1.3/=dependencies/rain-solmem-0.1.3/
+rainlang-interface-0.2.3/=dependencies/rainlang-interface-0.2.3/

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -1,4 +1,11 @@
 [[dependencies]]
+name = "@openzeppelin-contracts"
+version = "5.6.1"
+url = "https://soldeer-revisions.s3.amazonaws.com/@openzeppelin-contracts/5_6_1_15-03-2026_09:19:50_contracts.zip"
+checksum = "a3b6bc661be858c7c27f60a1708cbebe8c71034b4cc1e9fe270d0a05b069352f"
+integrity = "bce03af7ada1eee21a7fff393f238bcd7cd75a022a4db55ffb6b0dbb32433d35"
+
+[[dependencies]]
 name = "forge-std"
 version = "1.16.1"
 url = "https://soldeer-revisions.s3.amazonaws.com/forge-std/1_16_1_08-05-2026_08:51:16_forge-std-1.16.zip"
@@ -6,11 +13,18 @@ checksum = "839b61832925c7152c7b6dffbfa4998d9e606211179bd8f604733124e8a7cb57"
 integrity = "60e55d10150354ca4a1e2985c5456c834b92b82ef85ab0e1d92a7786cddbd219"
 
 [[dependencies]]
-name = "rain-interpreter-interface"
+name = "rain-lib-hash"
 version = "0.1.0"
-url = "https://soldeer-revisions.s3.amazonaws.com/rain-interpreter-interface/0_1_0_12-05-2026_18:43:02_rain.interpreter.zip"
-checksum = "887c4d5f1a87713c49f015b3fcdb295defbb495b126d15f9850c0ce72ef79639"
-integrity = "c1b89f8a7ad02507ceb051b6c0f2750f6abe1ba99ffdfe1c9ac93905db90e75d"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-lib-hash/0_1_0_12-05-2026_16:24:56_rain.lib.zip"
+checksum = "648f3e38b297dbd3ecb32b82c8b24c322f484e1734eb50fd393bc547c72b59b0"
+integrity = "91f5f679a0a27f096fdbc1e41195dd9f42cacfab15735efeb1101cc1b9215b47"
+
+[[dependencies]]
+name = "rain-math-binary"
+version = "0.1.4"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-math-binary/0_1_4_17-08-2026_05:22:01_rain.math.zip"
+checksum = "1787eb0bc883c4922deb5e547ecaf0bd0f9a31e99c51f3b11744c3324eb592f6"
+integrity = "857d22060d058ec173e88448c2d44f0cb884b2381669d0dbe1d3bebb168715ea"
 
 [[dependencies]]
 name = "rain-math-float"
@@ -18,3 +32,24 @@ version = "0.1.1"
 url = "https://soldeer-revisions.s3.amazonaws.com/rain-math-float/0_1_1_13-05-2026_13:48:34_rain.math.zip"
 checksum = "322956f272ae3073ee02b0e7301b8834f08f2de62bcd6c309c44e946d7cd7056"
 integrity = "dccdd4406a37db6af690872b805084a7dbe5211c57961a61ef083a7912ddbdc9"
+
+[[dependencies]]
+name = "rain-sol-codegen"
+version = "0.1.0"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-sol-codegen/0_1_0_09-05-2026_20:30:25_rain.sol.zip"
+checksum = "6b5abd394c5db86ac64214262b7a5115158f480b2fbd74442672dfe52bb67310"
+integrity = "e22748ce2ba7eca3ce71e23b2271d1c0f370b989507e784b0a4850a7a9e52157"
+
+[[dependencies]]
+name = "rain-solmem"
+version = "0.1.3"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-solmem/0_1_3_09-05-2026_19:49:33_rain.zip"
+checksum = "1d405bb81f7c9e56d1717de0d60da918d2fc2fa4db083efd2abe9906378d019f"
+integrity = "e879d2743f9d884f647b9dd489889a83f2cea5f76eb69409a113e1baa69d3643"
+
+[[dependencies]]
+name = "rainlang-interface"
+version = "0.2.3"
+url = "https://soldeer-revisions.s3.amazonaws.com/rainlang-interface/0_2_3_19-08-2026_03:51:33_rainlang.zip"
+checksum = "b8aace080832c17e29aaff400db11607314678035327598eaeca0a3496ac6933"
+integrity = "696f8521319c40532c169a44b5fe677b909ea392a6f82398239a4c2a8630c4ad"

--- a/src/interface/IRaindexV6.sol
+++ b/src/interface/IRaindexV6.sol
@@ -15,7 +15,7 @@ import {
 
     //forge-lint: disable-next-line(unused-import)
     IInterpreterStoreV3
-} from "rain-interpreter-interface-0.1.0/src/interface/IInterpreterCallerV4.sol";
+} from "rainlang-interface-0.2.3/src/interface/IInterpreterCallerV4.sol";
 
 /// Import unmodified structures from older versions of the Raindex interface.
 import {

--- a/src/interface/deprecated/v1/IOrderBookV1.sol
+++ b/src/interface/deprecated/v1/IOrderBookV1.sol
@@ -4,16 +4,16 @@ pragma solidity ^0.8.18;
 
 import {IERC3156FlashLender} from "../../ierc3156/IERC3156FlashLender.sol";
 //forge-lint: disable-next-line(unused-import)
-import {LibEvaluable} from "rain-interpreter-interface-0.1.0/src/lib/caller/LibEvaluable.sol";
+import {LibEvaluable} from "rainlang-interface-0.2.3/src/lib/caller/LibEvaluable.sol";
 import {
     EvaluableConfig,
     Evaluable,
     SignedContext,
     IInterpreterCallerV1
-} from "rain-interpreter-interface-0.1.0/src/interface/deprecated/v1/IInterpreterCallerV1.sol";
+} from "rainlang-interface-0.2.3/src/interface/deprecated/v1/IInterpreterCallerV1.sol";
 import {
     IExpressionDeployerV3
-} from "rain-interpreter-interface-0.1.0/src/interface/deprecated/v1/IExpressionDeployerV3.sol";
+} from "rainlang-interface-0.2.3/src/interface/deprecated/v1/IExpressionDeployerV3.sol";
 
 /// Configuration for a deposit. All deposits are processed by and for
 /// `msg.sender` so the vaults are unambiguous here.

--- a/src/interface/deprecated/v1/IOrderBookV1.sol
+++ b/src/interface/deprecated/v1/IOrderBookV1.sol
@@ -11,9 +11,7 @@ import {
     SignedContext,
     IInterpreterCallerV1
 } from "rainlang-interface-0.2.3/src/interface/deprecated/v1/IInterpreterCallerV1.sol";
-import {
-    IExpressionDeployerV3
-} from "rainlang-interface-0.2.3/src/interface/deprecated/v1/IExpressionDeployerV3.sol";
+import {IExpressionDeployerV3} from "rainlang-interface-0.2.3/src/interface/deprecated/v1/IExpressionDeployerV3.sol";
 
 /// Configuration for a deposit. All deposits are processed by and for
 /// `msg.sender` so the vaults are unambiguous here.

--- a/src/interface/deprecated/v2/IOrderBookV2.sol
+++ b/src/interface/deprecated/v2/IOrderBookV2.sol
@@ -11,9 +11,7 @@ import {
     SignedContextV1,
     IInterpreterCallerV2
 } from "rainlang-interface-0.2.3/src/interface/deprecated/v1/IInterpreterCallerV2.sol";
-import {
-    IExpressionDeployerV2
-} from "rainlang-interface-0.2.3/src/interface/deprecated/v1/IExpressionDeployerV2.sol";
+import {IExpressionDeployerV2} from "rainlang-interface-0.2.3/src/interface/deprecated/v1/IExpressionDeployerV2.sol";
 
 /// Configuration for a deposit. All deposits are processed by and for
 /// `msg.sender` so the vaults are unambiguous here.

--- a/src/interface/deprecated/v2/IOrderBookV2.sol
+++ b/src/interface/deprecated/v2/IOrderBookV2.sol
@@ -6,14 +6,14 @@ import {IERC3156FlashLender} from "../../ierc3156/IERC3156FlashLender.sol";
 import {
     EvaluableConfig,
     Evaluable
-} from "rain-interpreter-interface-0.1.0/src/interface/deprecated/v1/IInterpreterCallerV1.sol";
+} from "rainlang-interface-0.2.3/src/interface/deprecated/v1/IInterpreterCallerV1.sol";
 import {
     SignedContextV1,
     IInterpreterCallerV2
-} from "rain-interpreter-interface-0.1.0/src/interface/deprecated/v1/IInterpreterCallerV2.sol";
+} from "rainlang-interface-0.2.3/src/interface/deprecated/v1/IInterpreterCallerV2.sol";
 import {
     IExpressionDeployerV2
-} from "rain-interpreter-interface-0.1.0/src/interface/deprecated/v1/IExpressionDeployerV2.sol";
+} from "rainlang-interface-0.2.3/src/interface/deprecated/v1/IExpressionDeployerV2.sol";
 
 /// Configuration for a deposit. All deposits are processed by and for
 /// `msg.sender` so the vaults are unambiguous here.

--- a/src/interface/deprecated/v3/IOrderBookV3.sol
+++ b/src/interface/deprecated/v3/IOrderBookV3.sol
@@ -8,10 +8,10 @@ import {
     EvaluableConfigV3,
     IInterpreterCallerV2,
     SignedContextV1
-} from "rain-interpreter-interface-0.1.0/src/interface/deprecated/v1/IInterpreterCallerV2.sol";
+} from "rainlang-interface-0.2.3/src/interface/deprecated/v1/IInterpreterCallerV2.sol";
 import {
     IExpressionDeployerV3
-} from "rain-interpreter-interface-0.1.0/src/interface/deprecated/v1/IExpressionDeployerV3.sol";
+} from "rainlang-interface-0.2.3/src/interface/deprecated/v1/IExpressionDeployerV3.sol";
 
 /// Import unmodified structures from older versions of `IOrderBook`.
 import {IO, ClearConfig, ClearStateChange} from "../v2/IOrderBookV2.sol";

--- a/src/interface/deprecated/v3/IOrderBookV3.sol
+++ b/src/interface/deprecated/v3/IOrderBookV3.sol
@@ -9,9 +9,7 @@ import {
     IInterpreterCallerV2,
     SignedContextV1
 } from "rainlang-interface-0.2.3/src/interface/deprecated/v1/IInterpreterCallerV2.sol";
-import {
-    IExpressionDeployerV3
-} from "rainlang-interface-0.2.3/src/interface/deprecated/v1/IExpressionDeployerV3.sol";
+import {IExpressionDeployerV3} from "rainlang-interface-0.2.3/src/interface/deprecated/v1/IExpressionDeployerV3.sol";
 
 /// Import unmodified structures from older versions of `IOrderBook`.
 import {IO, ClearConfig, ClearStateChange} from "../v2/IOrderBookV2.sol";

--- a/src/interface/deprecated/v4/IOrderBookV4.sol
+++ b/src/interface/deprecated/v4/IOrderBookV4.sol
@@ -13,7 +13,7 @@ import {
 
     //forge-lint: disable-next-line(unused-import)
     IInterpreterStoreV2
-} from "rain-interpreter-interface-0.1.0/src/interface/deprecated/v2/IInterpreterCallerV3.sol";
+} from "rainlang-interface-0.2.3/src/interface/deprecated/v2/IInterpreterCallerV3.sol";
 
 /// Import unmodified structures from older versions of `IOrderBook`.
 import {ClearStateChange, ClearConfig, IO} from "../v3/IOrderBookV3.sol";

--- a/src/interface/deprecated/v5/IOrderBookV5.sol
+++ b/src/interface/deprecated/v5/IOrderBookV5.sol
@@ -13,7 +13,7 @@ import {
 
     //forge-lint: disable-next-line(unused-import)
     IInterpreterStoreV3
-} from "rain-interpreter-interface-0.1.0/src/interface/IInterpreterCallerV4.sol";
+} from "rainlang-interface-0.2.3/src/interface/IInterpreterCallerV4.sol";
 
 /// Import unmodified structures from older versions of `IOrderBook`.
 //forge-lint: disable-start(unused-import)


### PR DESCRIPTION
Refs rainlanguage/rainlang.interface#107

Migrates the soldeer dependency `rain-interpreter-interface` 0.1.0 -> `rainlang-interface` 0.2.3, following the interface repo/package rename (legacy `rain-interpreter-interface` is frozen; all new publishes go to `rainlang-interface`).

## Changes

- `foundry.toml`: `rain-interpreter-interface = "0.1.0"` -> `rainlang-interface = "0.2.3"`.
- All 11 imports across 6 `src/` files rewritten from `rain-interpreter-interface-0.1.0/src/...` to `rainlang-interface-0.2.3/src/...`. Every imported file and symbol exists unchanged in 0.2.3.
- Soldeer resolution is flat, so `[dependencies]` now also declares what `rainlang-interface-0.2.3/src` itself imports: `@openzeppelin-contracts` 5.6.1, `rain-lib-hash` 0.1.0, `rain-math-binary` 0.1.4, `rain-sol-codegen` 0.1.0, `rain-solmem` 0.1.3 (`forge-std` 1.16.1 already declared).
- `soldeer.lock` regenerated via `forge soldeer update`; stale `rain-interpreter-interface-0.1.0/` remapping removed from `remappings.txt`.
- Deleted stale `foundry.lock`, which still pinned the pre-soldeer `lib/rain.interpreter.interface` git submodule and made every `forge build` warn `Dependency 'lib/rain.interpreter.interface' not found at expected path` (sibling soldeer repos have no `foundry.lock`).
- `CLAUDE.md` dependencies section updated from the stale git-submodule description to the soldeer reality.
- `forge fmt` collapsed three single-symbol import blocks that fit within the line width now that the package name is shorter.

## Interface changes absorbed

None. Diffing `rain-interpreter-interface` 0.1.0 against `rainlang-interface` 0.2.3 package src: identical except `src/lib/parse/LibParseMeta.sol` and `src/lib/codegen/LibGenParseMeta.sol`, which only bump their `rain-math-binary` import path 0.1.1 -> 0.1.4. Neither file is imported by this repo. All symbols this repo consumes (`IInterpreterCallerV4`, `EvaluableV4`, `SignedContextV1`, `IInterpreterV4`, `IInterpreterStoreV3`, `LibEvaluable`, and the deprecated v1/v2 caller/deployer interfaces) are byte-identical.

## QA

- Discriminating tests: n/a — interface-only library with no test suite; `forge test` compiles and reports no tests, and this change is a dependency rename with zero behavioral surface.
- Mutations applied: n/a — no executable logic changed; the only mutation surface is import paths, where any wrong path fails compilation.
- Oracle: `forge build` green against the renamed package, plus a byte-level diff of the old (0.1.0) vs new (0.2.3) package src proving the consumed interfaces are identical.
- Category check: dependency migration (rename + version bump), no interface or behavior changes in this repo's own API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Maintenance**
  - Updated project dependencies to use the latest Rain language interfaces.
  - Added support for OpenZeppelin Contracts and additional Rain utility packages.
  - Updated dependency mappings to ensure consistent package resolution.

- **Documentation**
  - Clarified dependency management through Soldeer, including direct and transitive packages.
  - Removed outdated instructions for Git submodules and manual remappings.

- **Compatibility**
  - Updated legacy and current interfaces to reference the new dependency packages.
  - No contract declarations or user-facing behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->