### PR TITLE
chore(deps): bump rain-solmem 0.1.3 -> 0.1.26

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -35,7 +35,7 @@ rain-math-float = "0.1.1"
 rain-lib-hash = "0.1.0"
 rain-math-binary = "0.1.4"
 rain-sol-codegen = "0.1.0"
-rain-solmem = "0.1.3"
+rain-solmem = "0.1.26"
 
 [soldeer]
 recursive_deps = false

--- a/remappings.txt
+++ b/remappings.txt
@@ -4,5 +4,5 @@ rain-lib-hash-0.1.0/=dependencies/rain-lib-hash-0.1.0/
 rain-math-binary-0.1.4/=dependencies/rain-math-binary-0.1.4/
 rain-math-float-0.1.1/=dependencies/rain-math-float-0.1.1/
 rain-sol-codegen-0.1.0/=dependencies/rain-sol-codegen-0.1.0/
-rain-solmem-0.1.3/=dependencies/rain-solmem-0.1.3/
+rain-solmem-0.1.26/=dependencies/rain-solmem-0.1.26/
 rainlang-interface-0.2.3/=dependencies/rainlang-interface-0.2.3/

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -42,10 +42,10 @@ integrity = "e22748ce2ba7eca3ce71e23b2271d1c0f370b989507e784b0a4850a7a9e52157"
 
 [[dependencies]]
 name = "rain-solmem"
-version = "0.1.3"
-url = "https://soldeer-revisions.s3.amazonaws.com/rain-solmem/0_1_3_09-05-2026_19:49:33_rain.zip"
-checksum = "1d405bb81f7c9e56d1717de0d60da918d2fc2fa4db083efd2abe9906378d019f"
-integrity = "e879d2743f9d884f647b9dd489889a83f2cea5f76eb69409a113e1baa69d3643"
+version = "0.1.26"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-solmem/0_1_26_18-08-2026_16:20:17_rain.zip"
+checksum = "291a0acf805b8acd65dfb9e848e6670bde158120bb5b0bcdeeaf17c4084a134c"
+integrity = "54e56c1b10d05df72c1c3dcc8df92b99b9f01cd946363158b077c779ce4d20fa"
 
 [[dependencies]]
 name = "rainlang-interface"


### PR DESCRIPTION
Puts this repo on the latest published solmem, per the org-wide ruling to move everything to latest.

## Changes
- `foundry.toml`: `rain-solmem` soldeer pin `0.1.3` -> `0.1.26`.
- `soldeer.lock`: regenerated via `forge soldeer install`; only the `rain-solmem` entry moved.
- `remappings.txt`: `rain-solmem-0.1.3/` remapping replaced by `rain-solmem-0.1.26/`. Soldeer appended the new line and left the stale `0.1.3` one; the stale line is pruned by hand in this PR.

## Notes
- No file in `src/` imports solmem directly, and the transitive graph through `rainlang-interface-0.2.3` (LibEvaluable, IExpressionDeployerV2/V3) does not reach solmem either: the whole project compiles clean with only `rain-solmem-0.1.26` installed and no 0.1.3 remapping. The pin is carried for the dependency set, not for any current import.
- `LibStackPointer` was deleted upstream in solmem; nothing here imported it.
- No generated pointers/bytecode artifacts in this repo.

## QA
- Discriminating tests: n/a — this repo contains no tests at all (`forge test`: "No tests found in project"); the gate for a pin bump here is a clean compile of all 37 files against solmem 0.1.26, which passes locally.
- Mutations applied: n/a — the diff is a version pin, a regenerated lockfile, and one remapping line; no semantic line exists to mutate (a wrong path fails to compile).
- Oracle: the Solidity compiler over the full import graph — with the 0.1.3 remapping pruned and only 0.1.26 on disk, any surviving 0.1.3 reference would be a hard compile error.
- Category check: task asks to move the solmem pin to 0.1.26, regenerate soldeer.lock, and prune the stale remapping by hand; all three done, nothing else touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `rain-solmem` package to version 0.1.26.
  * Applied the update consistently across project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->